### PR TITLE
kernelscript: add a little detailed instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,14 +329,15 @@ sudo ./my_project          # Run the program
 1. **Install system dependencies (Debian/Ubuntu):**
    ```bash
    sudo apt update
-   sudo apt install libbpf-dev libelf-dev zlib1g-dev
+   sudo apt install libbpf-dev libelf-dev zlib1g-dev opam bpftool
    ```
 
 2. **Install KernelScript:**
    ```bash
    git clone https://github.com/multikernel/kernelscript.git
    cd kernelscript
-   opam install . --deps-only
+   opam init
+   opam install . --deps-only --with-test
    eval $(opam env) && dune build && dune install
    ```
 


### PR DESCRIPTION
The README.md was missing a couple of steps that are required when bootstrapping a new system that hasn't built opam before.

I had to add the steps in order for my setup to work, hope this can help others as well. I was building on Debian Trixie.