### PR TITLE
Fix kfunc/extern codegen so sched_ext_simple compiles

### DIFF
--- a/examples/sched_ext_simple.ks
+++ b/examples/sched_ext_simple.ks
@@ -3,17 +3,17 @@
 
 include "sched_ext_ops.kh"
 
-// kfuncs declarations (extracted from BTF)
-extern scx_bpf_select_cpu_dfl(p: *u8, prev_cpu: i32, wake_flags: u64, direct: *bool) -> i32
-extern scx_bpf_dsq_insert(p: *u8, dsq_id: u64, slice: u64, enq_flags: u64) -> void
-extern scx_bpf_consume(dsq_id: u64, cpu: i32, flags: u64) -> i32
+// kfuncs declarations (signatures match the kernel BTF for sched_ext)
+extern scx_bpf_select_cpu_dfl(p: *task_struct, prev_cpu: i32, wake_flags: u64, is_idle: *bool) -> i32
+extern scx_bpf_dsq_insert(p: *task_struct, dsq_id: u64, slice: u64, enq_flags: u64) -> void
+extern scx_bpf_dsq_move_to_local(dsq_id: u64) -> bool
 
 // Simple FIFO scheduler implementation
 @struct_ops("sched_ext_ops")
 impl simple_fifo_scheduler {
     
     // Select CPU for a waking task
-    fn select_cpu(p: *u8, prev_cpu: i32, wake_flags: u64) -> i32 {
+    fn select_cpu(p: *task_struct, prev_cpu: i32, wake_flags: u64) -> i32 {
         // Use default CPU selection with direct dispatch if idle core found
         var direct: bool = false
         var cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &direct)
@@ -27,56 +27,56 @@ impl simple_fifo_scheduler {
     }
     
     // Enqueue task into global FIFO queue
-    fn enqueue(p: *u8, enq_flags: u64) -> void {
+    fn enqueue(p: *task_struct, enq_flags: u64) -> void {
         // Simple FIFO: insert all tasks into global DSQ
         scx_bpf_dsq_insert(p, SCX_DSQ_GLOBAL, SCX_SLICE_DFL, enq_flags)
     }
     
     // Dispatch tasks from global queue to local CPU
-    fn dispatch(cpu: i32, prev: *u8) -> void {
-        // Try to consume a task from the global DSQ
-        if (scx_bpf_consume(SCX_DSQ_GLOBAL, cpu, 0) == 0) {
+    fn dispatch(cpu: i32, prev: *task_struct) -> void {
+        // Try to move a task from the global DSQ to this CPU's local DSQ
+        if (!scx_bpf_dsq_move_to_local(SCX_DSQ_GLOBAL)) {
             // No tasks available, CPU will go idle
         }
     }
     
     // Task becomes runnable
-    fn runnable(p: *u8, enq_flags: u64) -> void {
+    fn runnable(p: *task_struct, enq_flags: u64) -> void {
         // Optional: track runnable tasks
         // For simple FIFO, we don't need special handling
     }
-    
+
     // Task starts running
-    fn running(p: *u8) -> void {
+    fn running(p: *task_struct) -> void {
         // Optional: track running tasks
         // For simple FIFO, we don't need special handling
     }
-    
+
     // Task stops running
-    fn stopping(p: *u8, runnable: bool) -> void {
+    fn stopping(p: *task_struct, runnable: bool) -> void {
         // Optional: handle task stopping
         // For simple FIFO, we don't need special handling
     }
-    
+
     // Task becomes quiescent
-    fn quiescent(p: *u8, deq_flags: u64) -> void {
+    fn quiescent(p: *task_struct, deq_flags: u64) -> void {
         // Optional: handle quiescent tasks
         // For simple FIFO, we don't need special handling
     }
-    
+
     // Initialize new task
-    fn init_task(p: *u8, args: *u8) -> i32 {
+    fn init_task(p: *task_struct, args: *u8) -> i32 {
         // Return 0 for success
         return 0
     }
-    
+
     // Clean up exiting task
-    fn exit_task(p: *u8, args: *u8) -> void {
+    fn exit_task(p: *task_struct, args: *u8) -> void {
         // Optional cleanup for exiting tasks
     }
-    
+
     // Enable scheduler
-    fn enable(p: *u8) -> void {
+    fn enable(p: *task_struct) -> void {
         // Optional: scheduler enable logic
     }
     

--- a/src/bpf_helpers.ml
+++ b/src/bpf_helpers.ml
@@ -1,0 +1,254 @@
+(*
+ * Copyright 2026 Multikernel Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *)
+
+(** Standard BPF helper functions.
+
+    These are the legacy BPF helpers invoked through a fixed helper ID. libbpf's
+    [<bpf/bpf_helpers.h>] (via the auto-generated [bpf_helper_defs.h]) already
+    declares every one of them as a function pointer, so the eBPF C backend must
+    NOT emit its own [extern ... __ksym;] declaration for them - doing so clashes
+    with the libbpf declaration ("redefinition as different kind of symbol").
+
+    KernelScript uses the [extern] keyword for both kfuncs and helpers, so the
+    backend consults this set to tell them apart: a name here is a helper (skip
+    the __ksym declaration); anything else is a real kfunc (needs __ksym).
+
+    The list mirrors libbpf's [bpf_helper_defs.h], which is generated from the
+    kernel's [__BPF_FUNC_MAPPER] and only ever grows. *)
+
+let helper_names = [
+  "bpf_bind";
+  "bpf_bprm_opts_set";
+  "bpf_btf_find_by_name_kind";
+  "bpf_cgrp_storage_delete";
+  "bpf_cgrp_storage_get";
+  "bpf_check_mtu";
+  "bpf_clone_redirect";
+  "bpf_copy_from_user";
+  "bpf_copy_from_user_task";
+  "bpf_csum_diff";
+  "bpf_csum_level";
+  "bpf_csum_update";
+  "bpf_current_task_under_cgroup";
+  "bpf_d_path";
+  "bpf_dynptr_data";
+  "bpf_dynptr_from_mem";
+  "bpf_dynptr_read";
+  "bpf_dynptr_write";
+  "bpf_fib_lookup";
+  "bpf_find_vma";
+  "bpf_for_each_map_elem";
+  "bpf_get_attach_cookie";
+  "bpf_get_branch_snapshot";
+  "bpf_get_cgroup_classid";
+  "bpf_get_current_ancestor_cgroup_id";
+  "bpf_get_current_cgroup_id";
+  "bpf_get_current_comm";
+  "bpf_get_current_pid_tgid";
+  "bpf_get_current_task";
+  "bpf_get_current_task_btf";
+  "bpf_get_current_uid_gid";
+  "bpf_get_func_arg";
+  "bpf_get_func_arg_cnt";
+  "bpf_get_func_ip";
+  "bpf_get_func_ret";
+  "bpf_get_hash_recalc";
+  "bpf_get_listener_sock";
+  "bpf_get_local_storage";
+  "bpf_get_netns_cookie";
+  "bpf_get_ns_current_pid_tgid";
+  "bpf_get_numa_node_id";
+  "bpf_get_prandom_u32";
+  "bpf_get_retval";
+  "bpf_get_route_realm";
+  "bpf_get_smp_processor_id";
+  "bpf_get_socket_cookie";
+  "bpf_get_socket_uid";
+  "bpf_getsockopt";
+  "bpf_get_stack";
+  "bpf_get_stackid";
+  "bpf_get_task_stack";
+  "bpf_ima_file_hash";
+  "bpf_ima_inode_hash";
+  "bpf_inode_storage_delete";
+  "bpf_inode_storage_get";
+  "bpf_jiffies64";
+  "bpf_kallsyms_lookup_name";
+  "bpf_kptr_xchg";
+  "bpf_ktime_get_boot_ns";
+  "bpf_ktime_get_coarse_ns";
+  "bpf_ktime_get_ns";
+  "bpf_ktime_get_tai_ns";
+  "bpf_l3_csum_replace";
+  "bpf_l4_csum_replace";
+  "bpf_load_hdr_opt";
+  "bpf_loop";
+  "bpf_lwt_push_encap";
+  "bpf_lwt_seg6_action";
+  "bpf_lwt_seg6_adjust_srh";
+  "bpf_lwt_seg6_store_bytes";
+  "bpf_map_delete_elem";
+  "bpf_map_lookup_elem";
+  "bpf_map_lookup_percpu_elem";
+  "bpf_map_peek_elem";
+  "bpf_map_pop_elem";
+  "bpf_map_push_elem";
+  "bpf_map_update_elem";
+  "bpf_msg_apply_bytes";
+  "bpf_msg_cork_bytes";
+  "bpf_msg_pop_data";
+  "bpf_msg_pull_data";
+  "bpf_msg_push_data";
+  "bpf_msg_redirect_hash";
+  "bpf_msg_redirect_map";
+  "bpf_override_return";
+  "bpf_per_cpu_ptr";
+  "bpf_perf_event_output";
+  "bpf_perf_event_read";
+  "bpf_perf_event_read_value";
+  "bpf_perf_prog_read_value";
+  "bpf_probe_read";
+  "bpf_probe_read_kernel";
+  "bpf_probe_read_kernel_str";
+  "bpf_probe_read_str";
+  "bpf_probe_read_user";
+  "bpf_probe_read_user_str";
+  "bpf_probe_write_user";
+  "bpf_rc_keydown";
+  "bpf_rc_pointer_rel";
+  "bpf_rc_repeat";
+  "bpf_read_branch_records";
+  "bpf_redirect";
+  "bpf_redirect_map";
+  "bpf_redirect_neigh";
+  "bpf_redirect_peer";
+  "bpf_reserve_hdr_opt";
+  "bpf_ringbuf_discard";
+  "bpf_ringbuf_discard_dynptr";
+  "bpf_ringbuf_output";
+  "bpf_ringbuf_query";
+  "bpf_ringbuf_reserve";
+  "bpf_ringbuf_reserve_dynptr";
+  "bpf_ringbuf_submit";
+  "bpf_ringbuf_submit_dynptr";
+  "bpf_send_signal";
+  "bpf_send_signal_thread";
+  "bpf_seq_printf";
+  "bpf_seq_printf_btf";
+  "bpf_seq_write";
+  "bpf_set_hash";
+  "bpf_set_hash_invalid";
+  "bpf_set_retval";
+  "bpf_setsockopt";
+  "bpf_sk_ancestor_cgroup_id";
+  "bpf_sk_assign";
+  "bpf_skb_adjust_room";
+  "bpf_skb_ancestor_cgroup_id";
+  "bpf_skb_cgroup_classid";
+  "bpf_skb_cgroup_id";
+  "bpf_skb_change_head";
+  "bpf_skb_change_proto";
+  "bpf_skb_change_tail";
+  "bpf_skb_change_type";
+  "bpf_skb_ecn_set_ce";
+  "bpf_skb_get_tunnel_key";
+  "bpf_skb_get_tunnel_opt";
+  "bpf_skb_get_xfrm_state";
+  "bpf_skb_load_bytes";
+  "bpf_skb_load_bytes_relative";
+  "bpf_skb_output";
+  "bpf_skb_pull_data";
+  "bpf_skb_set_tstamp";
+  "bpf_skb_set_tunnel_key";
+  "bpf_skb_set_tunnel_opt";
+  "bpf_skb_store_bytes";
+  "bpf_skb_under_cgroup";
+  "bpf_skb_vlan_pop";
+  "bpf_skb_vlan_push";
+  "bpf_sk_cgroup_id";
+  "bpf_skc_lookup_tcp";
+  "bpf_skc_to_mptcp_sock";
+  "bpf_skc_to_tcp6_sock";
+  "bpf_skc_to_tcp_request_sock";
+  "bpf_skc_to_tcp_sock";
+  "bpf_skc_to_tcp_timewait_sock";
+  "bpf_skc_to_udp6_sock";
+  "bpf_skc_to_unix_sock";
+  "bpf_sk_fullsock";
+  "bpf_sk_lookup_tcp";
+  "bpf_sk_lookup_udp";
+  "bpf_sk_redirect_hash";
+  "bpf_sk_redirect_map";
+  "bpf_sk_release";
+  "bpf_sk_select_reuseport";
+  "bpf_sk_storage_delete";
+  "bpf_sk_storage_get";
+  "bpf_snprintf";
+  "bpf_snprintf_btf";
+  "bpf_sock_from_file";
+  "bpf_sock_hash_update";
+  "bpf_sock_map_update";
+  "bpf_sock_ops_cb_flags_set";
+  "bpf_spin_lock";
+  "bpf_spin_unlock";
+  "bpf_store_hdr_opt";
+  "bpf_strncmp";
+  "bpf_strtol";
+  "bpf_strtoul";
+  "bpf_sys_bpf";
+  "bpf_sys_close";
+  "bpf_sysctl_get_current_value";
+  "bpf_sysctl_get_name";
+  "bpf_sysctl_get_new_value";
+  "bpf_sysctl_set_new_value";
+  "bpf_tail_call";
+  "bpf_task_pt_regs";
+  "bpf_task_storage_delete";
+  "bpf_task_storage_get";
+  "bpf_tcp_check_syncookie";
+  "bpf_tcp_gen_syncookie";
+  "bpf_tcp_raw_check_syncookie_ipv4";
+  "bpf_tcp_raw_check_syncookie_ipv6";
+  "bpf_tcp_raw_gen_syncookie_ipv4";
+  "bpf_tcp_raw_gen_syncookie_ipv6";
+  "bpf_tcp_send_ack";
+  "bpf_tcp_sock";
+  "bpf_this_cpu_ptr";
+  "bpf_timer_cancel";
+  "bpf_timer_init";
+  "bpf_timer_set_callback";
+  "bpf_timer_start";
+  "bpf_trace_printk";
+  "bpf_trace_vprintk";
+  "bpf_user_ringbuf_drain";
+  "bpf_xdp_adjust_head";
+  "bpf_xdp_adjust_meta";
+  "bpf_xdp_adjust_tail";
+  "bpf_xdp_get_buff_len";
+  "bpf_xdp_load_bytes";
+  "bpf_xdp_output";
+  "bpf_xdp_store_bytes";
+]
+
+let helper_set =
+  let tbl = Hashtbl.create 256 in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) helper_names;
+  tbl
+
+(** [is_bpf_helper name] is true if [name] is a standard BPF helper already
+    declared by libbpf's bpf_helpers.h, and therefore must not be re-declared
+    as a [__ksym] extern by the eBPF C backend. *)
+let is_bpf_helper name = Hashtbl.mem helper_set name

--- a/src/dune
+++ b/src/dune
@@ -2,6 +2,7 @@
  (name kernelscript)
  (modules ast parser lexer parse type_checker symbol_table maps map_assignment
           map_operations ir ir_generator ir_analysis loop_analysis ir_function_system codegen_common
+          bpf_helpers
           multi_program_analyzer multi_program_ir_optimizer ebpf_c_codegen
           userspace_codegen evaluator safety_checker stdlib test_codegen
 tail_call_analyzer kernel_module_codegen dynptr_bridge

--- a/src/ebpf_c_codegen.ml
+++ b/src/ebpf_c_codegen.ml
@@ -284,6 +284,16 @@ let escape_c_string s =
 
 let ebpf_type_from_ir_type = Codegen_common.ir_type_to_c Codegen_common.EbpfKernel
 
+(** Type conversion for kfunc signatures. Unlike ebpf_type_from_ir_type, this keeps
+    [IRBool] as C [bool] rather than collapsing it to [__u8], so the emitted prototype
+    matches the kernel's actual kfunc signature (kfunc/extern type matching is strict). *)
+let rec kfunc_signature_type_to_c = function
+  | Ir.IRU8 -> "__u8" | Ir.IRU16 -> "__u16" | Ir.IRU32 -> "__u32" | Ir.IRU64 -> "__u64"
+  | Ir.IRI8 -> "__s8" | Ir.IRI16 -> "__s16" | Ir.IRI32 -> "__s32" | Ir.IRI64 -> "__s64"
+  | Ir.IRBool -> "bool" | Ir.IRChar -> "char" | Ir.IRVoid -> "void"
+  | Ir.IRPointer (inner_type, _) -> sprintf "%s*" (kfunc_signature_type_to_c inner_type)
+  | other -> ebpf_type_from_ir_type other
+
 (** Generate proper C declaration for eBPF, handling function pointers correctly *)
 let generate_ebpf_c_declaration = Codegen_common.c_declaration Codegen_common.EbpfKernel
 
@@ -3036,6 +3046,27 @@ let generate_declarations_in_source_order_unified ctx ir_multi_prog ~_btf_path _
         (* Generate struct_ops instance *)
         emit_line ctx (sprintf "/* eBPF struct_ops instance: %s */" struct_ops_instance.ir_instance_name);
         emit_blank_line ctx
+
+    | Ir.IRDeclKfuncDecl kfunc_decl ->
+        (* Emit a function-signature declaration so eBPF programs can call the kfunc.
+           Kernel-provided kfuncs need `extern ... __ksym;`; locally-defined @kfunc
+           functions just need a forward prototype. *)
+        let params_str = match kfunc_decl.Ir.ikfunc_params with
+          | [] -> "void"
+          | params -> String.concat ", " (List.map (fun (name, ir_type) ->
+              sprintf "%s %s" (kfunc_signature_type_to_c ir_type) name
+            ) params)
+        in
+        let return_type_str = kfunc_signature_type_to_c kfunc_decl.Ir.ikfunc_return_type in
+        if kfunc_decl.Ir.ikfunc_is_extern then
+          emit_line ctx (sprintf "extern %s %s(%s) __ksym;"
+            return_type_str kfunc_decl.Ir.ikfunc_name params_str)
+        else (
+          emit_line ctx "/* kfunc declaration */";
+          emit_line ctx (sprintf "%s %s(%s);"
+            return_type_str kfunc_decl.Ir.ikfunc_name params_str)
+        );
+        emit_blank_line ctx
   ) ir_multi_prog.Ir.source_declarations;
   
   (* Emit callbacks at the end if no functions were found (fallback) *)
@@ -3241,7 +3272,7 @@ let collect_callback_dependencies ir_multi_prog =
 
 (** Compile multi-program IR to eBPF C code with automatic tail call detection *)
 let compile_multi_to_c_with_tail_calls
-    ?(kfunc_declarations=[]) ?(tail_call_analysis=None) ?(btf_path=None)
+    ?(tail_call_analysis=None) ?(btf_path=None)
     (ir_multi_prog : Ir.ir_multi_program) =
   
   let ctx = create_c_context () in
@@ -3260,30 +3291,10 @@ let compile_multi_to_c_with_tail_calls
   let uses_dynptr = check_dynptr_usage ir_multi_prog in
   if uses_dynptr then generate_dynptr_macros ctx;
   
-  (* Generate kfunc declarations *)
-  let rec ast_type_to_c_type ast_type =
-    match ast_type with
-    | Ast.U8 -> "__u8" | Ast.U16 -> "__u16" | Ast.U32 -> "__u32" | Ast.U64 -> "__u64"
-    | Ast.I8 -> "__s8" | Ast.I16 -> "__s16" | Ast.I32 -> "__s32" | Ast.I64 -> "__s64"
-    | Ast.Bool -> "bool" | Ast.Char -> "char" | Ast.Void -> "void"
-    | Ast.Pointer inner_type -> sprintf "%s*" (ast_type_to_c_type inner_type)
-    | _ -> "void"
-  in
-  List.iter (fun kfunc ->
-    let params_str = String.concat ", " (List.map (fun (name, param_type) ->
-      let c_type = ast_type_to_c_type param_type in
-      sprintf "%s %s" c_type name
-    ) kfunc.Ast.func_params) in
-    let return_type_str = match Ast.get_return_type kfunc.Ast.func_return_type with
-      | Some ret_type -> ast_type_to_c_type ret_type
-      | None -> "void"
-    in
-    emit_line ctx (sprintf "/* kfunc declaration */");
-    emit_line ctx (sprintf "%s %s(%s);" return_type_str kfunc.Ast.func_name params_str);
-  ) kfunc_declarations;
-  
-  if kfunc_declarations <> [] then emit_blank_line ctx;
-  
+  (* Kfunc declarations (both kernel-provided `extern` kfuncs and locally-defined
+     @kfunc prototypes) are carried in the IR as IRDeclKfuncDecl and emitted in
+     source order by generate_declarations_in_source_order_unified. *)
+
   (* Generate string type definitions *)
   generate_string_typedefs ctx ir_multi_prog;
   
@@ -3316,16 +3327,16 @@ let compile_multi_to_c_with_tail_calls
   (final_output, final_tail_call_analysis)
 
 (** Multi-program compilation entry point that returns both code and tail call analysis *)
-let compile_multi_to_c ?(kfunc_declarations=[]) ?(tail_call_analysis=None) ?(btf_path=None) ir_multi_program =
+let compile_multi_to_c ?(tail_call_analysis=None) ?(btf_path=None) ir_multi_program =
   compile_multi_to_c_with_tail_calls
-    ~kfunc_declarations ~tail_call_analysis ~btf_path ir_multi_program
+    ~tail_call_analysis ~btf_path ir_multi_program
 
 (** Alias for backward compatibility with existing code *)
 let compile_multi_to_c_with_analysis = compile_multi_to_c
 
 (** Generate complete C program from multiple IR programs - main interface *)
-let generate_c_multi_program ?(kfunc_declarations=[]) ?(btf_path=None) ir_multi_prog =
-  let (c_code, _) = compile_multi_to_c ~kfunc_declarations ~btf_path ir_multi_prog in
+let generate_c_multi_program ?(btf_path=None) ir_multi_prog =
+  let (c_code, _) = compile_multi_to_c ~btf_path ir_multi_prog in
   c_code
 
 (** Generate complete C program from IR *)

--- a/src/ebpf_c_codegen.ml
+++ b/src/ebpf_c_codegen.ml
@@ -3050,23 +3050,29 @@ let generate_declarations_in_source_order_unified ctx ir_multi_prog ~_btf_path _
     | Ir.IRDeclKfuncDecl kfunc_decl ->
         (* Emit a function-signature declaration so eBPF programs can call the kfunc.
            Kernel-provided kfuncs need `extern ... __ksym;`; locally-defined @kfunc
-           functions just need a forward prototype. *)
-        let params_str = match kfunc_decl.Ir.ikfunc_params with
-          | [] -> "void"
-          | params -> String.concat ", " (List.map (fun (name, ir_type) ->
-              sprintf "%s %s" (kfunc_signature_type_to_c ir_type) name
-            ) params)
-        in
-        let return_type_str = kfunc_signature_type_to_c kfunc_decl.Ir.ikfunc_return_type in
-        if kfunc_decl.Ir.ikfunc_is_extern then
-          emit_line ctx (sprintf "extern %s %s(%s) __ksym;"
-            return_type_str kfunc_decl.Ir.ikfunc_name params_str)
+           functions just need a forward prototype. Standard BPF helpers are skipped
+           entirely - libbpf's bpf_helpers.h already declares them, and a __ksym
+           extern would clash with that declaration. *)
+        let name = kfunc_decl.Ir.ikfunc_name in
+        if kfunc_decl.Ir.ikfunc_is_extern && Bpf_helpers.is_bpf_helper name then
+          ()
         else (
-          emit_line ctx "/* kfunc declaration */";
-          emit_line ctx (sprintf "%s %s(%s);"
-            return_type_str kfunc_decl.Ir.ikfunc_name params_str)
-        );
-        emit_blank_line ctx
+          let params_str = match kfunc_decl.Ir.ikfunc_params with
+            | [] -> "void"
+            | params -> String.concat ", " (List.map (fun (pname, ir_type) ->
+                sprintf "%s %s" (kfunc_signature_type_to_c ir_type) pname
+              ) params)
+          in
+          let return_type_str = kfunc_signature_type_to_c kfunc_decl.Ir.ikfunc_return_type in
+          if kfunc_decl.Ir.ikfunc_is_extern then
+            emit_line ctx (sprintf "extern %s %s(%s) __ksym;"
+              return_type_str name params_str)
+          else (
+            emit_line ctx "/* kfunc declaration */";
+            emit_line ctx (sprintf "%s %s(%s);" return_type_str name params_str)
+          );
+          emit_blank_line ctx
+        )
   ) ir_multi_prog.Ir.source_declarations;
   
   (* Emit callbacks at the end if no functions were found (fallback) *)

--- a/src/ir.ml
+++ b/src/ir.ml
@@ -399,6 +399,18 @@ and ir_declaration_desc =
   | IRDeclProgramDef of ir_program
   | IRDeclStructOpsDef of ir_struct_ops_declaration
   | IRDeclStructOpsInstance of ir_struct_ops_instance
+  | IRDeclKfuncDecl of ir_kfunc_declaration
+
+(** Kfunc declaration - a function signature to declare at the top of the eBPF C file.
+    Covers both kernel-provided kfuncs (extern ... __ksym) and locally-defined @kfunc
+    prototypes. The full @kfunc body is emitted separately into the kernel module. *)
+and ir_kfunc_declaration = {
+  ikfunc_name: string;
+  ikfunc_params: (string * ir_type) list;
+  ikfunc_return_type: ir_type;
+  ikfunc_is_extern: bool; (* true: kernel-provided (extern __ksym); false: local @kfunc prototype *)
+  ikfunc_pos: ir_position;
+}
 
 (** Utility functions for creating IR nodes *)
 
@@ -535,6 +547,16 @@ let make_ir_struct_ops_def_decl struct_ops_def order =
 
 let make_ir_struct_ops_instance_decl struct_ops_instance order =
   make_ir_source_declaration (IRDeclStructOpsInstance struct_ops_instance) order struct_ops_instance.ir_instance_pos
+
+let make_ir_kfunc_decl name params return_type is_extern order pos =
+  make_ir_source_declaration
+    (IRDeclKfuncDecl {
+      ikfunc_name = name;
+      ikfunc_params = params;
+      ikfunc_return_type = return_type;
+      ikfunc_is_extern = is_extern;
+      ikfunc_pos = pos;
+    }) order pos
 
 let make_ir_multi_program source_name ?(source_declarations = [])
                           ?userspace_program ?(ring_buffer_registry = create_empty_ring_buffer_registry ())

--- a/src/ir_generator.ml
+++ b/src/ir_generator.ml
@@ -3375,8 +3375,32 @@ let lower_multi_program ast symbol_table source_name =
                   add_source_declaration (IRDeclStructOpsDef ir_struct_ops_decl) struct_def.struct_pos
               | None -> ())
          | Ast.AttributedFunction attr_func ->
-             (* Insert program entry functions at source position *)
              let func_name = attr_func.attr_function.func_name in
+             let is_kfunc = List.exists (function
+               | Ast.SimpleAttribute "kfunc" -> true
+               | _ -> false
+             ) attr_func.attr_list in
+             if is_kfunc then (
+               (* Locally-defined @kfunc: emit a prototype declaration so eBPF programs
+                  can call it. The body itself goes into the separate kernel module. *)
+               let func = attr_func.attr_function in
+               let ir_params = List.map (fun (name, param_type) ->
+                 (name, ast_type_to_ir_type param_type)
+               ) func.func_params in
+               let ir_return_type = match Ast.get_return_type func.func_return_type with
+                 | Some ret_type -> ast_type_to_ir_type ret_type
+                 | None -> IRVoid
+               in
+               add_source_declaration
+                 (IRDeclKfuncDecl {
+                    ikfunc_name = func.func_name;
+                    ikfunc_params = ir_params;
+                    ikfunc_return_type = ir_return_type;
+                    ikfunc_is_extern = false;
+                    ikfunc_pos = func.func_pos;
+                  }) func.func_pos
+             ) else
+             (* Insert program entry functions at source position *)
              (match Hashtbl.find_opt program_table func_name with
               | Some (_prog_def, ir_program) ->
                   add_source_declaration (IRDeclProgramDef ir_program) ir_program.ir_pos
@@ -3406,6 +3430,23 @@ let lower_multi_program ast symbol_table source_name =
                     | None -> ())
                | Ast.ImplStaticField _ -> ()
              ) impl_block.impl_items
+         | Ast.ExternKfuncDecl extern_decl ->
+             (* Kernel-provided kfunc: emit an `extern ... __ksym;` declaration *)
+             let ir_params = List.map (fun (name, param_type) ->
+               (name, ast_type_to_ir_type param_type)
+             ) extern_decl.Ast.extern_params in
+             let ir_return_type = match extern_decl.Ast.extern_return_type with
+               | Some ret_type -> ast_type_to_ir_type ret_type
+               | None -> IRVoid
+             in
+             add_source_declaration
+               (IRDeclKfuncDecl {
+                  ikfunc_name = extern_decl.Ast.extern_name;
+                  ikfunc_params = ir_params;
+                  ikfunc_return_type = ir_return_type;
+                  ikfunc_is_extern = true;
+                  ikfunc_pos = extern_decl.Ast.extern_pos;
+                }) extern_decl.Ast.extern_pos
          | _ -> () )
   );
   

--- a/src/main.ml
+++ b/src/main.ml
@@ -1025,7 +1025,12 @@ BPF_CC = clang
 CC = gcc
 
 # BPF compilation flags
-BPF_CFLAGS = -target bpf -O2 -Wall -Wextra -g
+# -fno-builtin: eBPF objects never link libc, but clang still recognises libc
+# names (exit, abort, ...) as builtins and applies their attributes. A struct_ops
+# method named after such a builtin (e.g. sched_ext_ops.exit, which clang treats
+# as noreturn) would otherwise be miscompiled to an empty section. eBPF C relies
+# only on __builtin_* intrinsics, which -fno-builtin does not affect.
+BPF_CFLAGS = -target bpf -O2 -Wall -Wextra -g -fno-builtin
 BPF_INCLUDES = -I.
 
 # Userspace compilation flags

--- a/src/main.ml
+++ b/src/main.ml
@@ -888,15 +888,6 @@ let compile_source input_file output_dir _verbose generate_makefile btf_vmlinux_
     let _resource_plan = Multi_program_ir_optimizer.plan_system_resources (Ir.get_programs ir_with_ring_buffer_analysis) ir_with_ring_buffer_analysis in
     let _optimization_strategies = Multi_program_ir_optimizer.generate_optimization_strategies multi_prog_analysis in
 
-    (* Extract kfunc declarations from AST for eBPF C generation *)
-    let kfunc_declarations = List.filter_map (function
-      | Ast.AttributedFunction attr_func ->
-          (match attr_func.attr_list with
-           | SimpleAttribute "kfunc" :: _ -> Some attr_func.attr_function
-           | _ -> None)
-      | _ -> None
-    ) annotated_ast in
-
     (* Perform tail call analysis on AST *)
     let tail_call_analysis = Tail_call_analyzer.analyze_tail_calls annotated_ast in
 
@@ -915,9 +906,9 @@ let compile_source input_file output_dir _verbose generate_makefile btf_vmlinux_
       { ir_with_ring_buffer_analysis with source_declarations = updated_source_declarations }
     in
 
-    (* Generate eBPF C code (with updated IR and kfunc declarations) *)
+    (* Generate eBPF C code (kfunc declarations are carried in the IR) *)
     let (ebpf_c_code, _final_tail_call_analysis) = Ebpf_c_codegen.compile_multi_to_c_with_analysis
-      ~kfunc_declarations ~tail_call_analysis:(Some tail_call_analysis) ~btf_path:btf_vmlinux_path updated_optimized_ir in
+      ~tail_call_analysis:(Some tail_call_analysis) ~btf_path:btf_vmlinux_path updated_optimized_ir in
 
     (* Analyze kfunc dependencies for automatic kernel module loading *)
     let ir_functions = List.map (fun prog -> prog.Ir.entry_function) (Ir.get_programs ir_with_ring_buffer_analysis) in

--- a/src/userspace_codegen.ml
+++ b/src/userspace_codegen.ml
@@ -1274,6 +1274,10 @@ let generate_declarations_in_source_order_userspace ir_multi_prog =
     | Ir.IRDeclStructOpsInstance _struct_ops_instance ->
         (* Skip struct_ops instances in userspace - they're handled separately *)
         ()
+
+    | Ir.IRDeclKfuncDecl _kfunc_decl ->
+        (* Skip kfunc declarations in userspace - they're eBPF-side only *)
+        ()
   ) ir_multi_prog.Ir.source_declarations;
   
   (* Return the declarations in the correct order (reverse since we prepended) *)

--- a/tests/test_definition_order.ml
+++ b/tests/test_definition_order.ml
@@ -107,6 +107,7 @@ let get_declaration_name = function
   | IRDeclProgramDef program -> program.entry_function.func_name
   | IRDeclStructOpsDef struct_ops -> struct_ops.ir_struct_ops_name
   | IRDeclStructOpsInstance instance -> instance.ir_instance_name
+  | IRDeclKfuncDecl kfunc_decl -> kfunc_decl.ikfunc_name
 
 (** Test type alias order preservation *)
 let test_type_alias_order () =

--- a/tests/test_extern.ml
+++ b/tests/test_extern.ml
@@ -158,13 +158,13 @@ let test_extern_kfunc_string_representation () =
 (** Test extern kfunc declarations are emitted into generated eBPF C with __ksym *)
 let test_extern_kfunc_ebpf_codegen () =
   let program = {|
-    extern bpf_ktime_get_ns() -> u64
+    extern scx_bpf_select_cpu_dfl(p: *u8, prev_cpu: i32) -> u64
     extern scx_bpf_dsq_insert(p: *u8, dsq_id: u64, slice: u64, enq_flags: u64) -> void
 
     @xdp
     fn test_program(ctx: *xdp_md) -> xdp_action {
-        var ts = bpf_ktime_get_ns()
-        scx_bpf_dsq_insert(null, 0, ts, 0)
+        var cpu = scx_bpf_select_cpu_dfl(null, 0)
+        scx_bpf_dsq_insert(null, 0, cpu, 0)
         return 2
     }
 
@@ -186,10 +186,48 @@ let test_extern_kfunc_ebpf_codegen () =
     try ignore (Str.search_forward (Str.regexp_string substr) generated_code 0); true
     with Not_found -> false
   in
-  check bool "Contains bpf_ktime_get_ns __ksym extern" true
-    (contains "extern __u64 bpf_ktime_get_ns(void) __ksym;");
+  check bool "Contains scx_bpf_select_cpu_dfl __ksym extern" true
+    (contains "extern __u64 scx_bpf_select_cpu_dfl(__u8* p, __s32 prev_cpu) __ksym;");
   check bool "Contains scx_bpf_dsq_insert __ksym extern" true
     (contains "extern void scx_bpf_dsq_insert(__u8* p, __u64 dsq_id, __u64 slice, __u64 enq_flags) __ksym;")
+
+(** Test that extern declarations naming standard BPF helpers are NOT re-declared
+    as __ksym externs (libbpf's bpf_helpers.h already declares them; a __ksym extern
+    would clash with the helper pointer definition). Real kfuncs still get __ksym. *)
+let test_extern_bpf_helper_not_redeclared () =
+  let program = {|
+    extern bpf_ktime_get_ns() -> u64
+    extern my_real_kfunc(x: u64) -> i32
+
+    @xdp
+    fn test_program(ctx: *xdp_md) -> xdp_action {
+        var ts = bpf_ktime_get_ns()
+        var r = my_real_kfunc(ts)
+        if (r > 0) {
+            return 1
+        }
+        return 2
+    }
+
+    fn main() -> i32 {
+        return 0
+    }
+  |} in
+
+  let ast = Parse.parse_string program in
+  let symbol_table = Symbol_table.build_symbol_table ast in
+  let (typed_ast, _) = Type_checker.type_check_and_annotate_ast ast in
+  let ir = Ir_generator.generate_ir typed_ast symbol_table "test" in
+  let (generated_code, _) = Ebpf_c_codegen.compile_multi_to_c_with_analysis ir in
+
+  let contains substr =
+    try ignore (Str.search_forward (Str.regexp_string substr) generated_code 0); true
+    with Not_found -> false
+  in
+  check bool "BPF helper bpf_ktime_get_ns is not re-declared as __ksym extern" false
+    (contains "bpf_ktime_get_ns(void) __ksym;");
+  check bool "Real kfunc my_real_kfunc is declared as __ksym extern" true
+    (contains "extern __s32 my_real_kfunc(__u64 x) __ksym;")
 
 (** Test extern keyword cannot be used in function definitions *)
 let test_extern_in_function_definition_fails () =
@@ -270,6 +308,7 @@ let tests = [
   "extern kfunc userspace restriction", `Quick, test_extern_kfunc_userspace_restriction;
   "extern kfunc string representation", `Quick, test_extern_kfunc_string_representation;
   "extern kfunc ebpf codegen", `Quick, test_extern_kfunc_ebpf_codegen;
+  "extern bpf helper not redeclared", `Quick, test_extern_bpf_helper_not_redeclared;
   "extern in function definition fails", `Quick, test_extern_in_function_definition_fails;
   "extern with body fails", `Quick, test_extern_with_body_fails;
   "extern mixed keywords fails", `Quick, test_extern_mixed_keywords_fails;

--- a/tests/test_extern.ml
+++ b/tests/test_extern.ml
@@ -155,6 +155,42 @@ let test_extern_kfunc_string_representation () =
   check bool "Contains bpf_ktime_get_ns extern" true contains_bpf_ktime;
   check bool "Contains bpf_trace_printk extern" true contains_bpf_trace
 
+(** Test extern kfunc declarations are emitted into generated eBPF C with __ksym *)
+let test_extern_kfunc_ebpf_codegen () =
+  let program = {|
+    extern bpf_ktime_get_ns() -> u64
+    extern scx_bpf_dsq_insert(p: *u8, dsq_id: u64, slice: u64, enq_flags: u64) -> void
+
+    @xdp
+    fn test_program(ctx: *xdp_md) -> xdp_action {
+        var ts = bpf_ktime_get_ns()
+        scx_bpf_dsq_insert(null, 0, ts, 0)
+        return 2
+    }
+
+    fn main() -> i32 {
+        return 0
+    }
+  |} in
+
+  let ast = Parse.parse_string program in
+  let symbol_table = Symbol_table.build_symbol_table ast in
+  let (typed_ast, _) = Type_checker.type_check_and_annotate_ast ast in
+  let ir = Ir_generator.generate_ir typed_ast symbol_table "test" in
+
+  (* Extern kfunc declarations are lowered into the IR; codegen needs no side-channel *)
+  let (generated_code, _) =
+    Ebpf_c_codegen.compile_multi_to_c_with_analysis ir in
+
+  let contains substr =
+    try ignore (Str.search_forward (Str.regexp_string substr) generated_code 0); true
+    with Not_found -> false
+  in
+  check bool "Contains bpf_ktime_get_ns __ksym extern" true
+    (contains "extern __u64 bpf_ktime_get_ns(void) __ksym;");
+  check bool "Contains scx_bpf_dsq_insert __ksym extern" true
+    (contains "extern void scx_bpf_dsq_insert(__u8* p, __u64 dsq_id, __u64 slice, __u64 enq_flags) __ksym;")
+
 (** Test extern keyword cannot be used in function definitions *)
 let test_extern_in_function_definition_fails () =
   let program = {|
@@ -233,6 +269,7 @@ let tests = [
   "extern kfunc type checking", `Quick, test_extern_kfunc_type_checking;
   "extern kfunc userspace restriction", `Quick, test_extern_kfunc_userspace_restriction;
   "extern kfunc string representation", `Quick, test_extern_kfunc_string_representation;
+  "extern kfunc ebpf codegen", `Quick, test_extern_kfunc_ebpf_codegen;
   "extern in function definition fails", `Quick, test_extern_in_function_definition_fails;
   "extern with body fails", `Quick, test_extern_with_body_fails;
   "extern mixed keywords fails", `Quick, test_extern_mixed_keywords_fails;

--- a/tests/test_kfunc_attribute.ml
+++ b/tests/test_kfunc_attribute.ml
@@ -148,18 +148,9 @@ let test_ebpf_kfunc_declarations () =
   (* Use the full multi-program type checker for proper expression typing *)
   let (typed_ast, _) = Type_checker.type_check_and_annotate_ast ast in
   let ir = Ir_generator.generate_ir typed_ast symbol_table "test" in
-  
-  (* Extract kfunc declarations *)
-  let kfunc_declarations = List.filter_map (function
-    | Ast.AttributedFunction attr_func ->
-        (match attr_func.attr_list with
-         | SimpleAttribute "kfunc" :: _ -> Some attr_func.attr_function
-         | _ -> None)
-    | _ -> None
-  ) typed_ast in
-  
-  (* Generate eBPF C code *)
-  let (generated_code, _) = Ebpf_c_codegen.compile_multi_to_c_with_analysis ~kfunc_declarations ir in
+
+  (* @kfunc declarations are lowered into the IR; codegen needs no side-channel *)
+  let (generated_code, _) = Ebpf_c_codegen.compile_multi_to_c_with_analysis ir in
   
   (* Check that kfunc declarations are generated *)
   check bool "Contains kfunc declaration" true

--- a/tests/test_struct_ops.ml
+++ b/tests/test_struct_ops.ml
@@ -1382,9 +1382,9 @@ let test_sched_ext_ops_btf_definition () =
 let test_struct_ops_can_call_kernel_functions () =
   let program = {|
     // Declare external kernel functions (kfuncs)
-    extern scx_bpf_select_cpu_dfl(p: *u8, prev_cpu: i32, wake_flags: u64, direct: *bool) -> i32
-    extern scx_bpf_dsq_insert(p: *u8, dsq_id: u64, slice: u64, enq_flags: u64) -> void
-    extern scx_bpf_consume(dsq_id: u64, cpu: i32, flags: u64) -> i32
+    extern scx_bpf_select_cpu_dfl(p: *task_struct, prev_cpu: i32, wake_flags: u64, is_idle: *bool) -> i32
+    extern scx_bpf_dsq_insert(p: *task_struct, dsq_id: u64, slice: u64, enq_flags: u64) -> void
+    extern scx_bpf_dsq_move_to_local(dsq_id: u64) -> bool
     
     // Kernel enum constants
     enum scx_dsq_id_flags {
@@ -1395,21 +1395,21 @@ let test_struct_ops_can_call_kernel_functions () =
     
     @struct_ops("sched_ext_ops")
     impl simple_scheduler {
-        fn select_cpu(p: *u8, prev_cpu: i32, wake_flags: u64) -> i32 {
-            var direct: bool = false
+        fn select_cpu(p: *task_struct, prev_cpu: i32, wake_flags: u64) -> i32 {
+            var is_idle: bool = false
             // This should be allowed - struct_ops functions run in kernel context
-            var cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &direct)
-            
-            if (direct == true) {
+            var cpu = scx_bpf_select_cpu_dfl(p, prev_cpu, wake_flags, &is_idle)
+
+            if (is_idle == true) {
                 scx_bpf_dsq_insert(p, SCX_DSQ_LOCAL, SCX_SLICE_DFL, 0)
             }
-            
+
             return cpu
         }
-        
-        fn dispatch(cpu: i32, prev: *u8) -> void {
+
+        fn dispatch(cpu: i32, prev: *task_struct) -> void {
             // This should also be allowed - calling kernel function from struct_ops
-            if (scx_bpf_consume(SCX_DSQ_GLOBAL, cpu, 0) == 0) {
+            if (!scx_bpf_dsq_move_to_local(SCX_DSQ_GLOBAL)) {
                 // No tasks available
             }
         }

--- a/tests/test_struct_ops.ml
+++ b/tests/test_struct_ops.ml
@@ -1255,6 +1255,54 @@ let test_sched_ext_ops_ebpf_codegen () =
   check bool "Instance has correct struct type" true
     (try ignore (Str.search_forward (Str.regexp "struct sched_ext_ops.*priority_scheduler") c_code 0); true with Not_found -> false)
 
+(** Test that a struct_ops method named after a clang builtin (e.g. sched_ext_ops
+    has an `exit` member) is emitted verbatim - same C symbol, SEC() suffix and
+    instance member. clang would otherwise treat `exit` as the `noreturn` builtin
+    and miscompile the body to an empty section; that is handled at build time by
+    `-fno-builtin` in the generated Makefile's BPF_CFLAGS, not by mangling the
+    name here. This test guards against the codegen reintroducing a rename. *)
+let test_struct_ops_builtin_method_name_emitted_verbatim () =
+  let program = {|
+    @struct_ops("sched_ext_ops")
+    impl builtin_name_sched {
+        fn select_cpu(p: *u8, prev_cpu: i32, wake_flags: u64) -> i32 {
+            return prev_cpu
+        }
+
+        fn init() -> i32 {
+            return 0
+        }
+
+        fn exit(info: *u8) -> void {
+            // cleanup
+        }
+
+        name: "builtin_sched",
+    }
+
+    fn main() -> i32 {
+        return register(builtin_name_sched)
+    }
+  |} in
+
+  let ast = Parse.parse_string program in
+  let ast_with_structs = ast @ Test_utils.StructOps.builtin_ast in
+  let symbol_table = Symbol_table.build_symbol_table ast_with_structs in
+  let (typed_ast, _) = Type_checker.type_check_and_annotate_ast ast_with_structs in
+  let ir = Ir_generator.generate_ir typed_ast symbol_table "test" in
+  let (c_code, _) = Ebpf_c_codegen.compile_multi_to_c_with_analysis ir in
+
+  (* The `exit` method is emitted verbatim - not renamed/mangled *)
+  check bool "exit method emitted as bare `void exit(`" true
+    (contains_substr c_code "void exit(");
+  check bool "SEC uses the verbatim member name" true
+    (contains_substr c_code "SEC(\"struct_ops/exit\")");
+  check bool "struct_ops instance wires .exit to the exit symbol" true
+    (contains_substr c_code ".exit = (void *)exit,");
+  (* Non-builtin names are likewise untouched *)
+  check bool "non-builtin method select_cpu unchanged" true
+    (contains_substr c_code "select_cpu(__u8* p")
+
 (** Test sched_ext_ops registry functionality *)
 let test_sched_ext_ops_registry () =
   (* Test that sched_ext_ops is known *)
@@ -1422,6 +1470,7 @@ let tests = [
   "sched_ext_ops parsing", `Quick, test_sched_ext_ops_parsing;
   "sched_ext_ops IR generation", `Quick, test_sched_ext_ops_ir_generation;
   "sched_ext_ops eBPF codegen", `Quick, test_sched_ext_ops_ebpf_codegen;
+  "struct_ops builtin method name emitted verbatim", `Quick, test_struct_ops_builtin_method_name_emitted_verbatim;
   "sched_ext_ops registry", `Quick, test_sched_ext_ops_registry;
   "sched_ext_ops BTF extraction", `Quick, test_sched_ext_ops_btf_extraction;
   "sched_ext_ops BTF definition", `Quick, test_sched_ext_ops_btf_definition;


### PR DESCRIPTION
## Summary

`sched_ext_simple.ks` (and other examples using `extern` kfunc declarations) compiled in KernelScript but produced eBPF C that failed to build. This branch fixes the three distinct problems found along the way.

### 1. Lower kfunc declarations into the IR

`extern` kfunc declarations were registered in the type checker and symbol table but never lowered into the IR, so the eBPF C backend never emitted `extern ... __ksym;` declarations for them — generated `.ebpf.c` called kfuncs like `scx_bpf_dsq_insert` with no declaration in scope.

Both kernel-provided `extern` kfuncs and locally-defined `@kfunc` prototypes are now represented as a new `IRDeclKfuncDecl` source declaration, emitted in source order from the IR. This replaces the `~kfunc_declarations` / `~extern_declarations` side-channel arguments that previously smuggled AST fragments past the IR into the backend.

### 2. Skip `__ksym` externs for standard BPF helpers

KernelScript uses `extern` for both kfuncs and BPF helpers, and shipped examples (`extern_kfunc_demo.ks`, `include_demo.ks`) declare helpers like `bpf_ktime_get_ns` with it. Emitting `extern ... __ksym;` for those clashed with libbpf's `bpf_helpers.h`, which already declares every helper.

A new `Bpf_helpers` module enumerates the standard helpers (mirroring libbpf's `bpf_helper_defs.h`); the backend skips the `__ksym` declaration for any `extern` naming one. Real kfuncs are unaffected.

### 3. Compile eBPF objects with `-fno-builtin`

struct_ops method names come from the kernel struct, so a `sched_ext_ops` scheduler must define an `exit` method. eBPF objects never link libc, but clang still recognises `exit` as a compiler builtin (`void(int) noreturn`) regardless of `-target bpf` — it compiled the fall-through body away to a zero-size section, and libbpf then rejected the object.

`-fno-builtin` is added to the generated Makefile's `BPF_CFLAGS`. eBPF C relies only on `__builtin_*` intrinsics (KernelScript emits `__builtin_memcpy`, never bare `memcpy`; struct-copy lowering uses the `llvm.memcpy` intrinsic) — none of which `-fno-builtin` affects.

## Testing

- Full suite: 85 test suites pass, 0 failures. New tests cover extern-kfunc IR codegen, the BPF-helper skip, and verbatim emission of builtin-named struct_ops methods.
- `sched_ext_simple` now builds fully end-to-end (`.ebpf.o`, skeleton, userspace binary).
- Verified every example's eBPF object builds with `-fno-builtin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)